### PR TITLE
[agent] Fallback to "sailfish" session if not running in-session

### DIFF
--- a/agent/agent.pro
+++ b/agent/agent.pro
@@ -3,7 +3,7 @@ TARGET = sailfish-polkit-agent
 CONFIG += sailfishapp
 QT += quick qml dbus
 
-PKGCONFIG += polkit-qt-agent-1 polkit-qt-core-1
+PKGCONFIG += polkit-qt-agent-1 polkit-qt-core-1 libsystemd-login
 
 SOURCES += main.cpp listener.cpp dialog.cpp
 HEADERS += listener.h dialog.h

--- a/rpm/sailfish-polkit-agent.spec
+++ b/rpm/sailfish-polkit-agent.spec
@@ -16,6 +16,7 @@ BuildRequires: pkgconfig(Qt5Qml)
 BuildRequires: pkgconfig(polkit-qt-agent-1)
 BuildRequires: pkgconfig(polkit-qt-core-1)
 BuildRequires: pkgconfig(sailfishapp) >= 0.0.10
+BuildRequires: pkgconfig(libsystemd-login)
 Requires: dbus
 Requires: procps
 


### PR DESCRIPTION
This allows a (patched) polkitd to connect together all non-session processes into a pseudo-session called "sailfish".

Goes with: https://git.merproject.org/thp/polkit/commit/d73b76da2479cba1a8aeb5bbdd63d6aa70c09c9c
